### PR TITLE
update circuitscape.org/linkagemapper to forward to new website

### DIFF
--- a/_layout/header.html
+++ b/_layout/header.html
@@ -16,7 +16,7 @@
         <a class="page-link" href="{{docs_link}}">Documentation</a>
         <a class="page-link" href="/downloads/">Downloads</a>
         <a class="page-link" href="/about/">About Circuitscape</a>
-        <a class="page-link" href="{{lm_link}}">Linkage Mapper</a>
+        <a class="page-link" href="/linkagemapper/">Linkage Mapper</a>
         <a class="page-link" href="/publications/">Publications</a>
         <a class="page-link" href="/authors/">Authors</a></div>
     </nav>

--- a/linkagemapper.md
+++ b/linkagemapper.md
@@ -1,0 +1,12 @@
++++
+title = "Linkage Mapper"
++++
+
+~~~
+<head>
+  <meta http-equiv="refresh" content="5; URL=https://www.linkagemapper.org/" />
+</head>
+<body>
+  <p>Linkage Mapper has moved to its own website, linkagemapper.org. If you are not redirected in 5 seconds <a href="https://linkagemapper.org/">click here</a>.</p>
+</body>
+~~~


### PR DESCRIPTION
This PR mostly does what @ranjanan's previous PR did, but I keep a page at circuitscape.org/linkagemapper that will automatically forward to linkagemapper.org. This way, if any old links point to circuitscape.org/linkagemapper, users will be automatically forwarded to the new website. cc @johngallo 